### PR TITLE
fix(gitmodules): switch submodule URLs from SSH to HTTPS for publishability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "scripts/python/shared"]
 	path = scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_scripts_python.git
+	url = https://github.com/abitofhelp/hybrid_scripts_python.git
 [submodule "test/scripts/python/shared"]
 	path = test/scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_test_python.git
+	url = https://github.com/abitofhelp/hybrid_test_python.git


### PR DESCRIPTION
## Summary

**Slice F1 of the functional publishability repair sequence.**
Restores HTTPS submodule URLs in `.gitmodules` so that downstream
consumers — and Alire's deployment of any future indexed `functional`
release — can clone the dev/tooling submodules without SSH
credentials.

Scope is deliberately **`.gitmodules` only** — reversible, two-URL
rewrite, no release execution.

Effectively reverses the URL portion of `f4863eb chore(submodules):
switch submodule URLs from HTTPS to SSH`, which is the commit that
introduced the publishability defect discovered while validating
clara's T1 unpin slice on 2026-06-06.

## Commit map

| # | SHA | Subject | Files |
|---|---|---|---|
| 1 | `2aabecc` | `fix(gitmodules): switch submodule URLs from SSH to HTTPS for publishability` | `.gitmodules` (+2 / -2) |

Diff total: 1 file, +2 / -2.

## What the change does (mechanical only)

```diff
 [submodule "scripts/python/shared"]
 	path = scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_scripts_python.git
+	url = https://github.com/abitofhelp/hybrid_scripts_python.git
 [submodule "test/scripts/python/shared"]
 	path = test/scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_test_python.git
+	url = https://github.com/abitofhelp/hybrid_test_python.git
```

No path changes. No submodule gitlink/pointer changes
(verified: `scripts/python/shared` stays at `cf36a0f`,
`test/scripts/python/shared` stays at `8e0fae1`). No other files
touched.

## Why this matters

Both submodule repositories (`hybrid_scripts_python` and
`hybrid_test_python`) are public on GitHub; HTTPS clones require
no credentials. The previous SSH URLs caused failures in any
consumer environment without SSH keys + a known_hosts entry for
`github.com`, including the canonical Ada dev container.

The defect was discovered while running clara's T1 unpin slice
local sanity (`alr update && alr build` against `functional = "^4.0.0"`
from the Alire community index). The Alire-indexed `functional 4.0.0`
deployment failed because `git submodule update` could not clone
the SSH URLs. This PR is the upstream-first fix; clara T1 remains
paused (branch `release/v1-0-0-unpin-functional` @ `3144709`,
local-only) until a new functional version carrying this fix is
published to the Alire community index.

## Position in the publishability sequence

This PR is **F1** in the Codex-reviewed sequence:

1. **F1 — `.gitmodules` HTTPS repair (this PR)**
2. F2 — `alire.toml` version bump + tag a new release
   (owner decision pending: **`4.0.1` vs `4.1.1` vs `4.2.0`**;
   plan recommendation: `4.1.1`, since `src/` has zero changes
   since v4.1.0 and HEAD is honestly the v4.1.0 line + a
   publishability patch)
3. F3 — `alr publish --skip-submit` dry-run; review generated
   manifest
4. F4 — `alr publish` submit to Alire community index
5. F5 — confirm index visibility (`alr search --crates functional`)
6. Resume clara T1 sanity at branch `3144709` after the new
   functional version is consumable

Each subsequent gate is owner-authorized + Codex-reviewed
independently.

## What this PR does NOT do

* No `alire.toml` edit — version stays `4.1.0` on the working
  tree; F2 owns the version bump.
* No submodule gitlink / pointer changes — the two submodules
  stay at their currently-recorded commits.
* No `src/` / `test/` / formal-doc / Makefile / CI changes.
* No tag, no GitHub Release, no `alr publish`.
* No dependency unpinning anywhere.
* No clara T1 changes — branch preserved local-only at `3144709`.

## Validation (performed before PR open)

Dev container (`dev-container-ada-system-1`):

1. **Clean clone + HTTPS submodule init** of this branch:
   - `git clone --branch fix/gitmodules-https-for-publishability` (local source)
   - `git submodule update --init --recursive`
   - Both submodules cloned via HTTPS without credentials.
   - Submodule status confirms expected gitlink commits
     (`cf36a0f...` / `8e0fae1...`).
2. **Clean consumer crate** with `[[depends-on]] functional = "^4.0.0"`
   and a local `[[pins]] functional = { path = "/tmp/functional-test" }`:
   - `alr update` resolved `functional 4.1.0` from the F1 clone
     (path pin).
   - `alr build` completed successfully in 0.37s; library and
     consumer binary linked cleanly.

Note: end-to-end consumer-from-Alire-index validation requires F4
(the alire-index PR) to land and is part of F5, not F1.

## Follow-ups deliberately deferred

* **F2 version-decision PR** — `4.0.1` vs `4.1.1` vs `4.2.0`
  awaits explicit owner choice.
* **F3 `alr publish --skip-submit`** — Codex-reviewed before submit.
* **F4 alire-index submission** — separately gated; **irreversible**
  once the alire-index PR opens.
* **F5 visibility check** — informational.
* **clara T1 resumption** — gated on F4+F5 + new functional version
  visibility in the community index.
* **Alire upstream bug report** — only file if behavior persists after
  F4 lands and the new manifest is consumed.
* **Ecosystem-wide unpins** (astengine / astfmt / adafmt) — same
  functional resolution path; all gated on the F-sequence outcome.

Refs: adafmt#42
