### PR TITLE
chore(release): prep v4.1.1 (publishability patch on the 4.1.0 line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-**Version:** 4.1.0<br>
-**Date:** 2025-12-18<br>
+**Version:** 4.1.1<br>
+**Date:** <YYYY-MM-DD pending tag><br>
 **SPDX-License-Identifier:** BSD-3-Clause<br>
 **License File:** See the LICENSE file in the project root<br>
-**Copyright:** © 2025 Michael Gardner, A Bit of Help, Inc.<br>
+**Copyright:** © 2025-2026 Michael Gardner, A Bit of Help, Inc.<br>
 **Status:** Released
 
 All notable changes to this project will be documented in this file.
@@ -13,6 +13,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+No unreleased changes yet.
+
+---
+
+## [4.1.1] - <YYYY-MM-DD pending tag>
+
+### Fixed
+
+- **Publishability of the Alire community-index source**: switch the
+  two `.gitmodules` submodule URLs from SSH (`git@github.com:...`)
+  back to HTTPS (`https://github.com/...`) so downstream consumers
+  and Alire's deployment of the published source can clone the
+  dev/tooling submodules without SSH credentials. Effectively
+  reverses the URL portion of `f4863eb chore(submodules): switch
+  submodule URLs from HTTPS to SSH`. Library API and runtime
+  behaviour are byte-identical to v4.1.0; this is a publishability
+  patch only.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE) [![Ada](https://img.shields.io/badge/Ada-2022-blue.svg)](https://ada-lang.io) [![SPARK](https://img.shields.io/badge/SPARK-Proved-green.svg)](https://www.adacore.com/about-spark) [![Alire](https://img.shields.io/badge/Alire-2.0+-blue.svg)](https://alire.ada.dev)
 
-**Version:** 4.1.0<br>
-**Date:** 2025-12-18<br>
+**Version:** 4.1.1<br>
+**Date:** <YYYY-MM-DD pending tag><br>
 **SPDX-License-Identifier:** BSD-3-Clause<br>
 **License File:** See the LICENSE file in the project root<br>
-**Copyright:** © 2025 Michael Gardner, A Bit of Help, Inc.<br>
+**Copyright:** © 2025-2026 Michael Gardner, A Bit of Help, Inc.<br>
 **Status:** Released
 
 ## Overview
@@ -352,7 +352,7 @@ A Bit of Help, Inc.
 
 ## Project Status
 
-**Status**: Production Ready (v4.1.0)
+**Status**: Production Ready (v4.1.1)
 
 - [x] Result[T,E] - 30 operations
 - [x] Option[T] - 25 operations

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "functional"
 description = "Functional Programming Library for Ada 2022"
-version = "4.1.0"
+version = "4.1.1"
 
 authors = ["A Bit of Help, Inc. - Michael Gardner"]
 maintainers = ["A Bit of Help, Inc. - Michael Gardner <mjgardner@abitofhelp.com>"]

--- a/config/README.md
+++ b/config/README.md
@@ -1,10 +1,10 @@
 # Functional Library - Embedded Restrictions
 
-**Version:** 4.1.0<br>
-**Date:** 2025-12-18<br>
+**Version:** 4.1.1<br>
+**Date:** <YYYY-MM-DD pending tag><br>
 **SPDX-License-Identifier:** BSD-3-Clause<br>
 **License File:** See the LICENSE file in the project root<br>
-**Copyright:** © 2025 Michael Gardner, A Bit of Help, Inc.<br>
+**Copyright:** © 2025-2026 Michael Gardner, A Bit of Help, Inc.<br>
 **Status:** Released
 
 ## Overview

--- a/src/version/functional-version.ads
+++ b/src/version/functional-version.ads
@@ -33,7 +33,7 @@ is
    --  Semantic Version Components
    Major : constant Natural := 4;
    Minor : constant Natural := 1;
-   Patch : constant Natural := 0;
+   Patch : constant Natural := 1;
 
    --  Pre-release identifier (e.g., "dev", "alpha.1", "beta.2", "rc.1")
    --  Empty string for stable releases
@@ -44,7 +44,7 @@ is
    Build_Metadata : constant String := "";
 
    --  Full version string (e.g., "0.1.0-dev", "1.2.3", "2.0.0-rc.1+build.456")
-   Version : constant String := "4.1.0";
+   Version : constant String := "4.1.1";
 
    --  Check if this is a pre-release version
    function Is_Prerelease return Boolean is (Prerelease'Length > 0);

--- a/test/alire.toml
+++ b/test/alire.toml
@@ -1,6 +1,6 @@
 name = "functional_tests"
 description = "Test suite for functional"
-version = "4.1.0"
+version = "4.1.1"
 authors = ["Michael Gardner"]
 maintainers = ["Michael Gardner <mike@abitofhelp.com>"]
 licenses = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

**Slice F2 of the functional publishability repair sequence.**
Bumps the version surfaces from `4.1.0` to `4.1.1`, adds a
`[4.1.1]` CHANGELOG section documenting the F1 publishability
fix (the `.gitmodules` SSH → HTTPS repair merged in #6), and
refreshes README + config/README metadata.

Scope is deliberately **6 files, ~15 line changes** — reversible,
no release execution.

Tag date uses a `<YYYY-MM-DD pending tag>` placeholder per the
no-drift policy established on clara T0; the real date is patched
in immediately before the v4.1.1 tag gate.

Per the F1 finding: the Ada library API and runtime behaviour at
HEAD are byte-identical to v4.1.0 (zero `src/` changes since the
v4.1.0 tag). **v4.1.1 is honestly a publishability patch on the
4.1.0 line**, hence the semver patch bump.

## Commit map

| # | SHA | Subject | Files |
|---|---|---|---|
| 1 | `5f94583` | `chore(release): prep v4.1.1 (publishability patch on the 4.1.0 line)` | 6 files (see §"What the change does" below) |

Diff total: 6 files, +32 / -14.

## What the change does (mechanical)

| File | Change |
|---|---|
| `alire.toml` | `version = "4.1.0"` → `"4.1.1"` |
| `test/alire.toml` | `version = "4.1.0"` → `"4.1.1"` |
| `src/version/functional-version.ads` | `Patch : constant Natural := 0;` → `1;`<br>`Version : constant String := "4.1.0";` → `"4.1.1";` |
| `CHANGELOG.md` | top metadata `Version: 4.1.0` → `4.1.1`<br>top metadata `Date: 2025-12-18` → `<YYYY-MM-DD pending tag>`<br>top metadata `Copyright © 2025` → `© 2025-2026`<br>add `## [4.1.1] - <YYYY-MM-DD pending tag>` section above `[4.1.0]` with the F1 publishability-fix entry<br>`[Unreleased]` body → `No unreleased changes yet.` |
| `README.md` | top metadata `Version`, `Date`, `Copyright` bumps (same shape as CHANGELOG)<br>status footer `Production Ready (v4.1.0)` → `(v4.1.1)` |
| `config/README.md` | top metadata `Version`, `Date`, `Copyright` bumps |

## Position in the publishability sequence

This PR is **F2** in the Codex-reviewed sequence:

1. F1 — `.gitmodules` HTTPS repair (merged in #6)
2. **F2 — release-prep PR for v4.1.1 (this PR)**
3. F2-tag — annotated `v4.1.1` tag push (separate gate)
4. F3 — `alr publish --skip-submit` dry-run; review generated manifest
5. F4 — `alr publish` submit to Alire community index
6. F5 — confirm index visibility (`alr search --crates functional`)
7. Resume clara T1 sanity at branch `3144709` after the new
   functional version is consumable

Each subsequent gate is owner-authorized and Codex-reviewed
independently.

## What this PR does NOT do

* No tag, no GitHub Release, no `alr publish`.
* No `.gitmodules` edit (F1 already did that).
* No `src/` (Ada source) changes — zero API delta vs v4.1.0.
* No `test/` (Ada tests) changes.
* No formal-doc edits — per owner direction, `docs/formal/{srs,sds,stg}.typ`
  stay at `version: "4.1.0"`, `status_date: "2026-04-27"`, `applies_to: "^4.1"`
  because the doc content is unchanged and `applies_to` already covers `4.1.1`.
* No `docs/index.md` / `docs/quick_start.md` / `docs/guides/*.md` edits —
  `**Doc Version:**` is doc-version, not product-version; leave per owner direction.
* No `README.md` line 110 change — dependency example `functional = "^4.1.0"`
  stays (semver caret covers 4.1.1).
* No `Makefile` / `*.gpr` / `.github/workflows/` changes.
* No `LICENSE` / `NOTICE` / `THIRD_PARTY` changes.
* No real date — only the placeholder `<YYYY-MM-DD pending tag>`.
* No dependency unpinning anywhere.
* No clara T1 changes — branch preserved local-only at `3144709`.

## Validation (performed before PR open)

Dev container (`dev-container-ada-system-1`):

1. **`alr build` on the F2 branch**:
   - `Functional.Version.Version` constant confirmed as `"4.1.1"`
     in the built tree.
   - `Success: Build finished successfully in 0.37 seconds.`
   - functional library archived (`libfunctional.a`).
2. **Clean consumer crate** with `[[depends-on]] functional = "^4.0.0"`
   and a local `[[pins]] functional = { path = "/workspace/functional" }`
   (pointing at the F2 branch):
   - `alr update` resolved `+. functional 4.1.1 (new,path=...)`.
   - `alr build` completed successfully in 0.46s; consumer binary
     linked cleanly.

Confirms the version bump propagates correctly through Alire's
dependency resolution and that consumers see `4.1.1` as expected.

## Follow-ups deliberately deferred

* **F2-tag** — annotated `v4.1.1` tag push to origin. Separately
  gated. If the real tag date differs from any value owner picks at
  tag time, patch CHANGELOG/README/config/README placeholders first
  (no-drift policy).
* **F3 `alr publish --skip-submit`** — Codex-reviewed before submit.
  Manifest must point at the exact `v4.1.1` tag SHA (NOT a moving
  branch), have no `[[pins]]`, no `path = ...`, no SSH URLs.
* **F4 alire-index submission** — separately gated; **irreversible**
  once the alire-index PR opens.
* **F5 visibility check** — informational.
* **clara T1 resumption** — gated on F4 + F5 visibility.
* **Formal-doc cover-page version** — deferred owner-decision item.
* **`release.py` script restoration** — `src/version/functional-version.ads`
  still claims auto-generation from a script that doesn't exist in
  the repo. NOT a v4.1.1 blocker; file post-publish cleanup ticket.

Refs: adafmt#42
